### PR TITLE
Add entertainment recommender web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # GuenhwyvarLabs
+
+This repository contains various experimental projects. The `entertainment_recommender` directory holds a simple Flask web application that asks a few questions and recommends an album, movie, or TV show based on your mood and genre preferences.
+Recommendations are fetched from the public iTunes Search API so an internet connection is required.
+
+## Entertainment Recommender App
+
+### Setup
+
+1. Install dependencies (preferably in a virtual environment):
+
+```bash
+pip install -r entertainment_recommender/requirements.txt
+```
+
+2. Run the app locally:
+
+```bash
+python entertainment_recommender/app.py
+```
+
+The application will start on [http://localhost:5000](http://localhost:5000). Open this URL in your browser to answer the questions and receive a recommendation.
+
+The app will attempt to fetch a random result from the iTunes Search API based on your chosen mood, medium, and genre. If the request fails, it falls back to a small built-in list of suggestions.
+

--- a/entertainment_recommender/app.py
+++ b/entertainment_recommender/app.py
@@ -1,0 +1,162 @@
+from flask import Flask, render_template, request
+import random
+import requests
+from typing import Optional
+
+app = Flask(__name__)
+
+RECOMMENDATIONS = {
+    "Album": {
+        "happy": {
+            "pop": "Future Nostalgia - Dua Lipa",
+            "rock": "American Idiot - Green Day",
+            "hip hop": "The College Dropout - Kanye West",
+            "electronic": "Discovery - Daft Punk",
+        },
+        "sad": {
+            "pop": "21 - Adele",
+            "rock": "OK Computer - Radiohead",
+            "hip hop": "To Pimp a Butterfly - Kendrick Lamar",
+            "electronic": "Immunity - Jon Hopkins",
+        },
+        "energetic": {
+            "pop": "1989 - Taylor Swift",
+            "rock": "Nevermind - Nirvana",
+            "hip hop": "DAMN. - Kendrick Lamar",
+            "electronic": "Cross - Justice",
+        },
+        "relaxed": {
+            "pop": "Lemonade - Beyoncé",
+            "rock": "Parachutes - Coldplay",
+            "hip hop": "Illmatic - Nas",
+            "electronic": "Play - Moby",
+        },
+    },
+    "Movie": {
+        "happy": {
+            "action": "Guardians of the Galaxy",
+            "comedy": "The Grand Budapest Hotel",
+            "drama": "The Pursuit of Happyness",
+            "sci-fi": "Back to the Future",
+        },
+        "sad": {
+            "action": "Logan",
+            "comedy": "Lost in Translation",
+            "drama": "Manchester by the Sea",
+            "sci-fi": "Children of Men",
+        },
+        "energetic": {
+            "action": "Mad Max: Fury Road",
+            "comedy": "Scott Pilgrim vs. the World",
+            "drama": "Whiplash",
+            "sci-fi": "Edge of Tomorrow",
+        },
+        "relaxed": {
+            "action": "Wonder Woman",
+            "comedy": "Chef",
+            "drama": "Big Fish",
+            "sci-fi": "Her",
+        },
+    },
+    "TV Show": {
+        "happy": {
+            "action": "The Mandalorian",
+            "comedy": "Brooklyn Nine-Nine",
+            "drama": "Ted Lasso",
+            "sci-fi": "Doctor Who",
+        },
+        "sad": {
+            "action": "The Punisher",
+            "comedy": "BoJack Horseman",
+            "drama": "The Handmaid's Tale",
+            "sci-fi": "Black Mirror",
+        },
+        "energetic": {
+            "action": "Stranger Things",
+            "comedy": "Parks and Recreation",
+            "drama": "24",
+            "sci-fi": "The Expanse",
+        },
+        "relaxed": {
+            "action": "MacGyver",
+            "comedy": "The Office",
+            "drama": "Friday Night Lights",
+            "sci-fi": "Star Trek: The Next Generation",
+        },
+    },
+}
+
+MOODS = ["happy", "sad", "energetic", "relaxed"]
+GENRES = [
+    "pop",
+    "rock",
+    "hip hop",
+    "electronic",
+    "action",
+    "comedy",
+    "drama",
+    "sci-fi",
+]
+MEDIUMS = ["Album", "Movie", "TV Show"]
+
+
+def fetch_from_itunes(mood: str, medium: str, genre: str) -> Optional[str]:
+    """Fetch a random suggestion from the iTunes Search API."""
+    search_term = f"{mood} {genre}".strip()
+    media_map = {
+        "Album": "music",
+        "Movie": "movie",
+        "TV Show": "tvShow",
+    }
+    media = media_map.get(medium)
+    if not media:
+        return None
+
+    params = {"term": search_term, "media": media, "limit": 50}
+    try:
+        resp = requests.get("https://itunes.apple.com/search", params=params, timeout=5)
+        resp.raise_for_status()
+        results = resp.json().get("results", [])
+        if results:
+            choice = random.choice(results)
+            return choice.get("trackName") or choice.get("collectionName")
+    except Exception as exc:
+        print(f"API fetch failed: {exc}")
+    return None
+
+
+def get_recommendation(mood: str, medium: str, genre: str) -> str:
+    """Return a recommendation, trying the online API first."""
+    suggestion = fetch_from_itunes(mood, medium, genre)
+    if suggestion:
+        return suggestion
+
+    mood = mood.lower()
+    genre = genre.lower()
+    mood_data = RECOMMENDATIONS.get(medium, {}).get(mood)
+    if not mood_data:
+        return "No recommendation available."
+    return mood_data.get(genre, "No recommendation available.")
+
+
+@app.route("/", methods=["GET", "POST"])
+def index():
+    recommendation = None
+    if request.method == "POST":
+        mood = request.form.get("mood", "").lower()
+        medium = request.form.get("medium", "")
+        genre = request.form.get("genre", "").lower()
+        recommendation = get_recommendation(mood, medium, genre)
+    else:
+        mood = medium = genre = ""
+    return render_template(
+        "index.html",
+        moods=MOODS,
+        mediums=MEDIUMS,
+        genres=GENRES,
+        recommendation=recommendation,
+    )
+
+
+if __name__ == "__main__":
+    app.run(debug=True, host="127.0.0.1", port=5000)

--- a/entertainment_recommender/requirements.txt
+++ b/entertainment_recommender/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+requests

--- a/entertainment_recommender/templates/index.html
+++ b/entertainment_recommender/templates/index.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Entertainment Recommender</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        form { margin-bottom: 20px; }
+        label { display: block; margin-top: 10px; }
+    </style>
+</head>
+<body>
+    <h1>Entertainment Recommender</h1>
+    <form method="post">
+        <label>Mood:
+            <select name="mood" required>
+                <option value="" disabled selected>Select your mood</option>
+                {% for mood in moods %}
+                <option value="{{ mood }}">{{ mood.title() }}</option>
+                {% endfor %}
+            </select>
+        </label>
+        <label>Medium:
+            <select name="medium" required>
+                <option value="" disabled selected>Select a medium</option>
+                {% for medium in mediums %}
+                <option value="{{ medium }}">{{ medium }}</option>
+                {% endfor %}
+            </select>
+        </label>
+        <label>Genre:
+            <select name="genre" required>
+                <option value="" disabled selected>Select a genre</option>
+                {% for genre in genres %}
+                <option value="{{ genre }}">{{ genre.title() }}</option>
+                {% endfor %}
+            </select>
+        </label>
+        <button type="submit">Get Recommendation</button>
+    </form>
+    {% if recommendation %}
+    <h2>Recommendation:</h2>
+    <p>{{ recommendation }}</p>
+    {% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `entertainment_recommender` Flask app with a basic HTML form
- document setup and usage in README
- reach out to iTunes Search API for dynamic recommendations

## Testing
- `pytest -q`
- `pip install Flask requests` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_684b352f1248832cb51e57f6a93f0fd1